### PR TITLE
Fix a fatal error and also a bug where the user's request to delete syndication link was ignored.

### DIFF
--- a/bridgy.php
+++ b/bridgy.php
@@ -14,8 +14,8 @@ function syn_bridgy_publish_link($response, $source, $target, $post_ID) {
 		preg_match('~https?://(?:www\.)?(brid.gy|localhost:8080)/publish/(.*)~', $target, $matches)) {
       $urls = get_post_meta($post_id, 'syndication_urls',true);
       $urls .= '\n' . $json->url;    
-      $meta = syn_clean_urls($_POST[ 'syndication_urls' ]);  
-      update_post_meta( $post_id, 'syndication_urls', $meta);
+      $meta = syn_clean_urls( implode("\n", $_POST[ 'syndication_urls' ]) );
+      update_post_meta( $post_id, 'syndication_urls', explode("\n", $meta) );
 	}
 }
 add_action('webmention_post_send', 'syn_bridgy_publish_link', 10, 4);

--- a/bridgy.php
+++ b/bridgy.php
@@ -14,8 +14,8 @@ function syn_bridgy_publish_link($response, $source, $target, $post_ID) {
 		preg_match('~https?://(?:www\.)?(brid.gy|localhost:8080)/publish/(.*)~', $target, $matches)) {
       $urls = get_post_meta($post_id, 'syndication_urls',true);
       $urls .= '\n' . $json->url;    
-      $meta = syn_clean_urls( implode("\n", $_POST[ 'syndication_urls' ]) );
-      update_post_meta( $post_id, 'syndication_urls', explode("\n", $meta) );
+      $meta = syn_clean_urls( explode("\n", $_POST[ 'syndication_urls' ]) );
+      update_post_meta( $post_id, 'syndication_urls', implode("\n", $meta) );
 	}
 }
 add_action('webmention_post_send', 'syn_bridgy_publish_link', 10, 4);

--- a/syn-postmeta.php
+++ b/syn-postmeta.php
@@ -77,7 +77,7 @@ function synbox_save_post_meta( $post_id ) {
 		}
 	}
     if( (isset( $_POST[ 'syndication_urls' ]))&& !(empty($_POST[ 'syndication_urls' ])) ) {
-        $meta = syn_clean_urls_string($_POST[ 'syndication_urls' ]);
+        $meta = syn_clean_urls($_POST[ 'syndication_urls' ]);
 	   	  update_post_meta( $post_id, 'syndication_urls', $meta);
     }
 }

--- a/syn-postmeta.php
+++ b/syn-postmeta.php
@@ -76,9 +76,13 @@ function synbox_save_post_meta( $post_id ) {
 			return;
 		}
 	}
-    if( (isset( $_POST[ 'syndication_urls' ]))&& !(empty($_POST[ 'syndication_urls' ])) ) {
-        $meta = syn_clean_urls($_POST[ 'syndication_urls' ]);
-	   	  update_post_meta( $post_id, 'syndication_urls', $meta);
+    if ( isset( $_POST[ 'syndication_urls' ]) ) {
+        if ( empty($_POST['syndication_urls']) ) {
+            delete_post_meta($post_id, 'syndication_urls');
+        } else {
+            $meta = syn_clean_urls( explode("\n", $_POST[ 'syndication_urls' ]) );
+            update_post_meta( $post_id, 'syndication_urls', implode("\n", $meta) );
+        }
     }
 }
 

--- a/syndication-links.php
+++ b/syndication-links.php
@@ -36,19 +36,32 @@ function get_syn_network_strings() {
                 return apply_filters( 'syn_network_strings', $strings );
         }
 
-function syn_clean_urls($string) {
-  $urls = explode("\n", $string);
-  $array=array();
-  foreach ( (array) $urls as $url ) {
-    $url = trim($url);
-    if(!filter_var($url, FILTER_VALIDATE_URL))
-      { continue; }
-    $url = esc_url_raw($url);
-    $array[] = $url;
-   }
-  $array = array_unique($array);
-  return(implode("\n", $array));
- }
+/**
+ * Filters incoming URLs.
+ *
+ * @param array $urls An array of URLs to filter.
+ * @return array A filtered array of unique URLs.
+ * @uses syn_clean_url
+ */
+function syn_clean_urls($urls) {
+  $array = array_map('syn_clean_url', $urls);
+  return array_filter(array_unique($array));
+}
+
+/**
+ * Filters a single syndication URL.
+ *
+ * @param string $string A string that is expected to be a syndication URL.
+ * @return string|bool The filtered and escaped URL string, or FALSE if invalid.
+ * @used-by syn_clean_urls
+ */
+function syn_clean_url($string) {
+  $url = trim($string);
+  if ( !filter_var($url, FILTER_VALIDATE_URL) )
+    { return false ; }
+  $url = esc_url_raw($url);
+  return $url;
+}
 
 // Return Syndication URLs as part of the JSON Rest API
 add_filter("json_prepare_post",'json_rest_add_synmeta',10,3);


### PR DESCRIPTION
This is a super-request that contains #5 and a new commit that refactors the metadata save handler to correctly deal with the case where a user deletes syndication URLs that they have previously entered. See commit messages for details.