### PR TITLE
Allows get_syndication_links to be called without displaying text_before

### DIFF
--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -472,9 +472,9 @@ class Syn_Meta {
 
 		return $textbefore . $before . join( $sep, $links ) . $after;
 	}
-	
+
 	function get_syndication_links_text_before() {
-		$display = self::get_syndicaiton_links_display_option();
+		$display = self::get_syndication_links_display_option();
 
 		return ( 'hidden' !== $display ) ? '<span class="' . $r['text-css'] . '">' . get_option( 'syndication-links_text_before' ) . '</span>' : '';
 	}

--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -402,7 +402,7 @@ class Syn_Meta {
 		if ( empty( $urls ) ) {
 			return '';
 		}
-		$display = self::get_syndicaiton_links_display_option();
+		$display = self::get_syndication_links_display_option();
 		$r = wp_parse_args( $args, self::get_syndication_links_display_defaults() );
 
 		$strings = self::get_network_strings();
@@ -419,7 +419,7 @@ class Syn_Meta {
 		return $links;
 	}
 
-	function get_syndicaiton_links_display_option() {
+	function get_syndication_links_display_option() {
 		$display = get_option( 'syndication-links_display' );
 		if ( ! is_singular() ) {
 			$display = get_option( 'syndication-links_archives' ) ? $display : 'hidden';
@@ -429,7 +429,7 @@ class Syn_Meta {
 	}
 
 	function get_syndication_links_display_defaults() {
-		$display = self::get_syndicaiton_links_display_option();
+		$display = self::get_syndication_links_display_option();
 		$defaults = array(
 			'style' => 'ul',
 			'text' => in_array( $display, array( 'text', 'iconstext' ) ),

--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -445,13 +445,12 @@ class Syn_Meta {
 
 	function get_syndication_links( $object = null, $args = array() ) {
 		$links = self::get_syndication_links_elements($object,$args);
-		$display = self::get_syndicaiton_links_display_option();
 		$r = wp_parse_args( $args, self::get_syndication_links_display_defaults() );
 
 		if($r['show_text_before'])
-			$textbefore = ( 'hidden' !== $display ) ? '<span class="' . $r['text-css'] . '">' . get_option( 'syndication-links_text_before' ) . '</span>' : '';
+			$textbefore = self::get_syndication_links_text_before();
 		else
-			$textbefore = '';
+			$textbefore = "";
 
 		switch ( $r['style'] ) {
 			case 'p':
@@ -475,6 +474,12 @@ class Syn_Meta {
 	}
 
 } // End Class
+
+function get_syndication_links_text_before() {
+	$display = self::get_syndicaiton_links_display_option();
+
+	return ( 'hidden' !== $display ) ? '<span class="' . $r['text-css'] . '">' . get_option( 'syndication-links_text_before' ) . '</span>' : '';
+}
 
 
 function get_syndication_links( $meta_type, $object_id = null, $args = array() ) {

--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -397,25 +397,13 @@ class Syn_Meta {
 		return get_syndication_links( get_comment( $comment_ID ), $args );
 	}
 
-	public static function get_syndication_links( $object = null, $args = array() ) {
+	public static function get_syndication_links_elements( $object = null, $args = array() ) {
 		$urls = self::get_syndication_links_data( $object );
 		if ( empty( $urls ) ) {
 			return '';
 		}
-		$display = get_option( 'syndication-links_display' );
-		if ( ! is_singular() ) {
-			$display = get_option( 'syndication-links_archives' ) ? $display : 'hidden';
-		}
-		$defaults = array(
-			'style' => 'ul',
-			'text' => in_array( $display, array( 'text', 'iconstext' ) ),
-			'icons' => in_array( $display, array( 'icons', 'iconstext' ) ),
-			'container-css' => 'relsyn',
-			'single-css' => 'syn-link',
-			'text-css' => 'syn-text',
-		);
-		$defaults = apply_filters( 'syn_links_display_defaults', $defaults );
-		$r = wp_parse_args( $args, $defaults );
+		$display = self::get_syndicaiton_links_display_option();
+		$r = wp_parse_args( $args, self::get_syndication_links_display_defaults() );
 
 		$strings = self::get_network_strings();
 		$rel = is_single() ? ' rel="syndication">' : '>';
@@ -428,7 +416,42 @@ class Syn_Meta {
 
 			$links[] = sprintf( '<a aria-label="%1$s" class="u-syndication %2$s" href="%3$s"%4$s %5$s</a>', $name, $r['single-css'], esc_url( $url ), $rel, $syn );
 		}
-		$textbefore = ( 'hidden' !== $display ) ? '<span class="' . $r['text-css'] . '">' . get_option( 'syndication-links_text_before' ) . '</span>' : '';
+		return $links;
+	}
+
+	function get_syndicaiton_links_display_option() {
+		$display = get_option( 'syndication-links_display' );
+		if ( ! is_singular() ) {
+			$display = get_option( 'syndication-links_archives' ) ? $display : 'hidden';
+		}
+
+		return $display;
+	}
+
+	function get_syndication_links_display_defaults() {
+		$display = self::get_syndicaiton_links_display_option();
+		$defaults = array(
+			'style' => 'ul',
+			'text' => in_array( $display, array( 'text', 'iconstext' ) ),
+			'icons' => in_array( $display, array( 'icons', 'iconstext' ) ),
+			'container-css' => 'relsyn',
+			'single-css' => 'syn-link',
+			'text-css' => 'syn-text',
+			'show_text_before' => true,
+		);
+
+		return apply_filters( 'syn_links_display_defaults', $defaults );
+	}
+
+	function get_syndication_links( $object = null, $args = array() ) {
+		$links = self::get_syndication_links_elements($object,$args);
+		$display = self::get_syndicaiton_links_display_option();
+		$r = wp_parse_args( $args, self::get_syndication_links_display_defaults() );
+
+		if($r['show_text_before'])
+			$textbefore = ( 'hidden' !== $display ) ? '<span class="' . $r['text-css'] . '">' . get_option( 'syndication-links_text_before' ) . '</span>' : '';
+		else
+			$textbefore = '';
 
 		switch ( $r['style'] ) {
 			case 'p':

--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -419,7 +419,7 @@ class Syn_Meta {
 		return $links;
 	}
 
-	function get_syndication_links_display_option() {
+	function static get_syndication_links_display_option() {
 		$display = get_option( 'syndication-links_display' );
 		if ( ! is_singular() ) {
 			$display = get_option( 'syndication-links_archives' ) ? $display : 'hidden';

--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -472,14 +472,14 @@ class Syn_Meta {
 
 		return $textbefore . $before . join( $sep, $links ) . $after;
 	}
+	
+	function get_syndication_links_text_before() {
+		$display = self::get_syndicaiton_links_display_option();
+
+		return ( 'hidden' !== $display ) ? '<span class="' . $r['text-css'] . '">' . get_option( 'syndication-links_text_before' ) . '</span>' : '';
+	}
 
 } // End Class
-
-function get_syndication_links_text_before() {
-	$display = self::get_syndicaiton_links_display_option();
-
-	return ( 'hidden' !== $display ) ? '<span class="' . $r['text-css'] . '">' . get_option( 'syndication-links_text_before' ) . '</span>' : '';
-}
 
 
 function get_syndication_links( $meta_type, $object_id = null, $args = array() ) {


### PR DESCRIPTION
* Breaks get_syndication_links out into smaller pieces
* Adds get_syndication_links_elements which returns array of anchor tags
* Adds get_syndication_links_display_defaults to return default options
* Adds get_syndication_links_text_before to return textbefore on it's own.

Fixes #58 