### PR TITLE
Don't return syndication link text if no links

### DIFF
--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -476,7 +476,10 @@ class Syn_Meta {
 				$after = '</li></ul>';
 		}
 
-		return $textbefore . $before . join( $sep, $links ) . $after;
+		if($links != "")
+			return $textbefore . $before . join( $sep, $links ) . $after;
+		else
+			return "";
 	}
 
 	public static function get_post_syndication_links( $post_ID = null, $args = array() ) {


### PR DESCRIPTION
Ensures we don't output anything when links don't exist.