### PR TITLE
UI enhancements

### DIFF
--- a/includes/class-post-syndication.php
+++ b/includes/class-post-syndication.php
@@ -85,8 +85,10 @@ class Post_Syndication {
 
 	public static function register( $object ) {
 		if ( $object instanceof Syndication_Provider ) {
-			static::$targets[ $object->get_uid() ] = $object;
-			return true;
+			if ( ! empty( $object->get_uid() ) ) {
+				static::$targets[ $object->get_uid() ] = $object;
+				return true;
+			}
 		}
 		return false;
 	}
@@ -297,4 +299,3 @@ class Post_Syndication {
 	}
 
 } // End Class
-

--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -203,13 +203,24 @@ class Syn_Meta {
 		if ( ! $urls ) {
 			$urls = array( '' );
 		}
-		echo '<span class="button-primary" id="add-syn-link-button">' . esc_html__( 'Add', 'syndication-links' ) . '</span></br>';
-		echo '<p class="syndication_url_list"><label for="syndication_urls">';
-		esc_html_e( 'Add Links to this same content on other sites', 'syndication-links' );
+
+		$html  = '<div class="syndication_url_list">';
+		$html .= sprintf( '<label for="syndication_urls">%s</label>',
+			esc_html__( 'Add Links to this same content on other sites', 'syndication-links' )
+		);
+		$html .= '<ul>';
 		foreach ( $urls as $url ) {
-			echo '<input type="text" name="syndication_urls[]" class="widefat" id="syndication_urls" value="' . esc_url_raw( $url ) . '" /><br />';
+			$html .= sprintf( '<li><input type="text" name="syndication_urls[]" class="widefat" id="syndication_urls" value="%s" /></li>',
+				esc_url_raw( $url )
+			);
 		}
-		echo '</label></p>';
+		$html .= '</ul>';
+		$html .= sprintf( '<button class="button-primary" id="add-syn-link-button">%s</button>',
+			esc_html__( 'Add', 'syndication-links' )
+		);
+		$html .= '</div>';
+
+		print $html;
 	}
 
 	/* Save the meta box's metadata. */

--- a/js/synlinks.js
+++ b/js/synlinks.js
@@ -2,16 +2,15 @@ jQuery( document ).ready( function( $ ) {
 
 jQuery( document )
 	$( '#add-syn-link-button' ).click( function( event ) {
-		 $( '<input type="text" name="syndication_urls[]" class="widefat" id="syndication_urls" value="" /><br />' ).appendTo( '.syndication_url_list' );
+		event.preventDefault();
+		$(this).prev( '.syndication_url_list > ul' ).append( '<li><input type="text" name="syndication_urls[]" class="widefat" value="" /></li>' );
 	});
 	$( '#add-custom-webmention-button' ).click( function( event ) {
 		var n = $( "#custom_webmention > li" ).length;
-		var s = '<li><input type="text" placeholder="Name" name="syndication_links_custom_posse[' + n + '][name]" /><input placeholder="UID" type="text" name="syndication_links_custom_posse[' + n + '][uid]" /><input type="text" placeholder="Target URL" name="syndication_links_custom_posse[' + n + '][target]" /></li>' 
+		var s = '<li><input type="text" placeholder="Name" name="syndication_links_custom_posse[' + n + '][name]" /><input placeholder="UID" type="text" name="syndication_links_custom_posse[' + n + '][uid]" /><input type="text" placeholder="Target URL" name="syndication_links_custom_posse[' + n + '][target]" /></li>';
 		$( s ).appendTo( '#custom_webmention' );
 	});
 	$( '#delete-custom-webmention-button' ).click( function( event ) {
 		$( '#custom_webmention li:last-of-type' ).remove();
 	});
 });
-
-


### PR DESCRIPTION
## 1. Prevent empty checkbox in Syndicate To meta box
Somehow (didn’t check why/how exactly, perhaps because of how defaults work on the settings page) [`Post_Syndication:register`](https://github.com/dshanske/syndication-links/blob/master/includes/class-post-syndication.php#L86-L92) would register an empty provider that would cause an extra checkbox with no label to appear in the _Syndicate To_ meta box within the WordPress editor. 

I added a check that prevents any provider from being registered unless it has at least a UID value – which also solves the glitch with the extra checkbox.

## 2. Moved button, enhanced markup in Syndication Links meta box
There wasn’t anything functionally wrong, so this one doesn’t ‘fix’ anything but optics. I enhanced markup a little by wrapping all inputs in a real list (`<ul>`); this adds a little air between list items without any additional CSS.

I also placed the _Add_ button below the list instead of above. While I think I can imagine what made you place it above in the first place, I found it more intuitive below, plus it acts nicely: the button stays in place when you click it while the list moves upwards with every new line added to it. So I thought this could be a nice visual enhancement.

Finally, I removed the `id` attribute from new inputs added via jQuery because ids got duplicated (which can be an a11y issue) and they didn’t seem functionally necessary as long as `name` attributes stay intact.

I tested this commit in both, the Classic Editor and Block Editor (which is why I [added `event.preventDefault()`](https://github.com/dshanske/syndication-links/commit/786b88c9fdecf568c1fab9532ff203981176235b#diff-7139b8dea6a41a3b739669f8773082b4R5) because without it and the Classic Editor active, the page would reload when I clicked the button).