### PR TITLE
`add_syncation_links` make all parameters optional

### DIFF
--- a/includes/class-syn-meta.php
+++ b/includes/class-syn-meta.php
@@ -330,7 +330,7 @@ class Syn_Meta {
 		return preg_replace( '/^([a-zA-Z0-9].*\.)?([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.[a-zA-Z.]{2,})$/', '$2', $parse );
 	}
 
-	public static function add_syndication_link( $object = null, $uri, $replace = false ) {
+	public static function add_syndication_link( $object = null, $uri = null, $replace = false ) {
 		if ( ! $object ) {
 			$object = get_post();
 		}


### PR DESCRIPTION
Resolves `Deprecated: Required parameter $uri follows optional parameter $object in /srv/www/html/wp-content/plugins/syndication-links/includes/class-syn-meta.php on line 333` on PHP 8.0+