### PR TITLE
Attempt to fix upstream #175

### DIFF
--- a/includes/class-syn-config.php
+++ b/includes/class-syn-config.php
@@ -335,7 +335,7 @@ class Syn_Config {
 		$name    = $args['label_for'];
 		$checked = get_option( $args['label_for'] );
 		echo "<input name='" . esc_attr( $name ) . "' type='hidden' value='0' />";
-		echo "<input name='" . esc_attr( $name ) . "' type='checkbox' value='1' " . checked( 1, $checked, false ) . ' /> ';
+		echo "<input name='" . esc_attr( $name ) . "' type='checkbox' value='1' id='" . esc_attr( $name ) . "' " . checked( 1, $checked, false ) . ' /> ';
 	}
 
 	public static function select_callback( array $args ) {
@@ -355,8 +355,8 @@ class Syn_Config {
 		$options = $args['list'];
 		echo '<fieldset>';
 		foreach ( $options as $key => $value ) {
-			echo '<input type="radio" name="' . esc_attr( $name ) . '" id="' . esc_attr( $name ) . '-' . esc_attr( $key ) . '" value="' . esc_attr( $key ) . '" ' . checked( $key, $select, false ) . ' />';
-			echo '<label for="' . esc_attr( $name ) . '-' . esc_attr( $key ) . '">' . esc_attr( $value ) . '</label>';
+			echo '<label><input type="radio" name="' . esc_attr( $name ) . '" value="' . esc_attr( $key ) . '" ' . checked( $key, $select, false ) . ' />';
+			echo ' ' . esc_attr( $value ) . '</label>';
 			echo '<br />';
 		}
 		echo '</fieldset>';
@@ -373,9 +373,9 @@ class Syn_Config {
 				continue;
 			}
 			?>
-			 <li><input name='<?php echo esc_attr( $args['label_for'] ); ?>[]' type='checkbox' value='<?php echo esc_attr( $post_type->name ); ?>' <?php checked( in_array( $post_type->name, $option ), true ); ?>/> 
-			 <label for="<?php echo esc_attr( $post_type->name ); ?>"><?php echo esc_html( $post_type->label ); ?></label>
-			</li> 
+			<li><label><input name='<?php echo esc_attr( $args['label_for'] ); ?>[]' type='checkbox' value='<?php echo esc_attr( $post_type->name ); ?>' <?php checked( in_array( $post_type->name, $option ), true ); ?>/>
+			<?php echo esc_html( $post_type->label ); ?></label>
+			</li>
 			<?php
 		}
 		echo '</ul>';


### PR DESCRIPTION
See commit.

What I wasn't able to fix (I'm not very used to working with that part of the settings API and tend to just hand-type the table HTML) is the fact that some `th`s still have a label in them that doesn't really point anywhere; like for the radio groups, each radio button has its own label, but then the overall setting also has a "label," which ... can be confusing?

Tried removing the `label_for` argument, but then it's obviously no longer set in the callback and everything sort of stops working. There's probably something else that can be done, but, as I said, not super experienced with this specific functionality.

To test, just click all the labels and see if the inputs respond accordingly.