### PR TITLE
Add Autoshare For Twitter Support

### DIFF
--- a/includes/class-social-plugins.php
+++ b/includes/class-social-plugins.php
@@ -7,7 +7,6 @@ class Social_Plugins {
 		add_filter( 'get_post_syndication_links', array( 'Social_Plugins', 'add_syn_plugins' ) );
 		add_filter( 'syn_links_url_to_name', array( 'Social_Plugins', 'url_to_name_plugins' ), 10, 2 );
 		add_action( 'wpt_tweet_posted', array( 'Social_Plugins', 'wptotwitter_to_syn_links' ), 10, 2 );
-		add_action( 'autoshare_for_twitter_after_status_update', array( 'Social_Plugins', 'autoshare_for_twitter_after_status_update' ), 10, 3 );
 	}
 
 	public static function url_to_name_plugins( $name, $url ) {
@@ -21,18 +20,18 @@ class Social_Plugins {
 		}
 	}
 
-	public static function array_flatten( $array ) { 
-		if ( ! is_array( $array ) ) { 	 
-			return false; 
-		} 
-		$result = array(); 
-		foreach ($array as $key => $value) { 
-			if (is_array($value)) { 
-			$result = array_merge($result, self::array_flatten($value)); 
-			} else { 
-			$result[$key] = $value; 
-			} 
-		} 
+	public static function array_flatten( $array ) {
+		if ( ! is_array( $array ) ) {
+			return false;
+		}
+		$result = array();
+		foreach ($array as $key => $value) {
+			if (is_array($value)) {
+			$result = array_merge($result, self::array_flatten($value));
+			} else {
+			$result[$key] = $value;
+			}
+		}
 		return $result;
 	}
 
@@ -46,7 +45,7 @@ class Social_Plugins {
 			return $urls;
 		}
 		$keys = array_keys( $keys );
-		
+
 		foreach(  $keys as $key ) {
 			if ( 0 === strpos( $key, 'snap' ) && 6 === strlen( $key ) ) {
 				$meta = get_post_meta( get_the_ID(), $key, true );
@@ -84,17 +83,6 @@ class Social_Plugins {
 			}
 		}
 		return array_merge( $see_on, $urls );
-	}
-
-	public static function autoshare_for_twitter_after_status_update( $response, $update_data, $post ) {
-		$post = get_post( $post );
-		if ( $post ) {
-			$data = get_post_meta( $post->ID, 'autoshare_status', true );
-			$tweet_id = $tweet_status['twitter_id'] ?? '';
-			$handle   = $tweet_status['handle'] ?? 'i/web';
-			$url = esc_url( 'https://twitter.com/' . $handle . '/status/' . $tweet_id );
-			add_post_syndication_link( $post->ID, $url );
-		}
 	}
 
 	public static function add_links_from_snap() {

--- a/includes/class-social-plugins.php
+++ b/includes/class-social-plugins.php
@@ -7,6 +7,7 @@ class Social_Plugins {
 		add_filter( 'get_post_syndication_links', array( 'Social_Plugins', 'add_syn_plugins' ) );
 		add_filter( 'syn_links_url_to_name', array( 'Social_Plugins', 'url_to_name_plugins' ), 10, 2 );
 		add_action( 'wpt_tweet_posted', array( 'Social_Plugins', 'wptotwitter_to_syn_links' ), 10, 2 );
+		add_action( 'autoshare_for_twitter_post_tweet_status_updated', array( 'Social_Plugins', 'handle_syndication_after_tweet_status_updated' ), 10, 2 );
 	}
 
 	public static function url_to_name_plugins( $name, $url ) {
@@ -174,6 +175,47 @@ class Social_Plugins {
 		);
 
 		return add_post_syndication_link( $id, $url );
+	}
+
+	/**
+	 * Check if URL is a valid tweet URL.
+	 *
+	 * @param string $url URL to check.
+	 * @return bool
+	 */
+	private static function is_valid_tweet_url( $url ) {
+		return (
+			! empty( $url ) &&
+			false !== strpos( $url, '/status/' ) &&
+			strlen( $url ) > 30 &&
+			wp_http_validate_url( $url )
+		);
+	}
+
+	/**
+	 * Handle syndication after tweet status meta is updated.
+	 *
+	 * @param int   $post_id    The post ID.
+	 * @param array $tweet_meta The tweet meta array containing tweet status data.
+	 */
+	public static function handle_syndication_after_tweet_status_updated( $post_id, $tweet_meta ) {
+		if ( empty( $tweet_meta ) ) {
+			return;
+		}
+
+		// Handle both single and multiple tweet formats.
+		$tweets = isset( $tweet_meta['twitter_id'] ) ? array( $tweet_meta ) : $tweet_meta;
+
+		foreach ( $tweets as $tweet ) {
+			if ( 'published' === $tweet['status'] && ! empty( $tweet['twitter_id'] ) ) {
+				$uri = \TenUp\AutoshareForTwitter\Utils\link_from_twitter( $tweet );
+
+				// Only add valid tweet URLs.
+				if ( self::is_valid_tweet_url( $uri ) ) {
+					Syn_Meta::add_syndication_link( get_post_type( $post_id ), $post_id, $uri );
+				}
+			}
+		}
 	}
 
 } // End Class


### PR DESCRIPTION
This hook in the Syndication Links plugin creates a conflict with the ongoing Autoshare for X + Syndication Links integration currently in progress at https://github.com/10up/autoshare-for-twitter/pull/331.  

Incomplete Tweet URLs, such as `https://twitter.com/i/web/status/`, are being generated and added because the Syndication Links plugin hooks into `autoshare_for_twitter_after_status_update` to handle the same functionality being developed in the Autoshare for Twitter plugin PR.  

Additionally, this implementation contains a bug in the variable names – it attempts to use the undefined variable `$tweet_status`, leaving `$data` unused.  

Finally, by using `add_post_syndication_link( $post->ID, $url )`, it does not account for saving syndication link metadata in custom post types. This contrasts with using `\Syn_Meta::add_syndication_link( $type, $post_id, $uri );`, which allows specifying the post type object where the metadata should be saved through the `$type` parameter.