### PR TITLE
Update class-post-syndication.php for any post type

### DIFF
--- a/includes/class-post-syndication.php
+++ b/includes/class-post-syndication.php
@@ -159,6 +159,7 @@ class Post_Syndication {
 	public static function do_pings() {
 		$syndicate = get_posts(
 			array(
+				'post_type'   => 'any',
 				'meta_key'    => '_syndicate-to',
 				'fields'      => 'ids',
 				'nopaging'    => true,


### PR DESCRIPTION
Bridgy syndications were not being processed for my site’s custom post type posts.

In Post_Syndication::do_pings(), the queue scan is:

get_posts(array(
  'meta_key'    => '_syndicate-to',
  'fields'      => 'ids',
  'nopaging'    => true,
  'post_status' => 'publish',
));

On my site, queued items are on a custom post type. In cron/CLI context, the above query defaults to only 'post' post types, so it returns an empty array, so _syndicate-to is never deleted and syndication never runs.

Raw SQL confirms the rows exist.

Also, this test returns the expected IDs immediately:

get_posts(array(
  'post_type'   => 'any',
  'meta_key'    => '_syndicate-to',
  'fields'      => 'ids',
  'nopaging'    => true,
  'post_status' => 'publish',
));

So the issue does appear to be that do_pings() omits post_type and therefore misses queued custom post type posts.

Adding this criteria to the query in my local copy of the plugin caused syndication to start working as expected. 